### PR TITLE
Mandelbrot fix [D broadwell issue]

### DIFF
--- a/bench/algorithm/mandelbrot/1.d
+++ b/bench/algorithm/mandelbrot/1.d
@@ -6,78 +6,39 @@ import std.digest.md;
 
 static immutable VLEN = 8;
 
-version(LDC){
-    import core.simd;
-    alias Vec = double8;
-    
-    pragma(inline, true):
-    ubyte mbrot8(Vec cr, double civ) {
-        immutable Vec ci = civ;
-        Vec zr = 0.0;
-        Vec zi = 0.0;
-        Vec tr = 0.0;
-        Vec ti = 0.0;
-        Vec absz = 0.0;
-        foreach(l; 0 .. 10) {
-            foreach(k; 0 .. 5) {
-                zi = (zr + zr) * zi + ci;
-                zr = tr - ti + cr;
-                tr = zr * zr;
-                ti = zi * zi;
-            }
-            absz = tr + ti;
-            bool terminate = true;
-            foreach(i; 0 .. 8)
-                if (absz[i] <= 4.0) {
-                    terminate = false;
-                    break;
-                }
-            if (terminate)
-                return 0u;
-        }
-        ubyte accu;
-        foreach(i; 0 .. VLEN)
-            if (absz[i] <= 4.0) {
-                accu |= 0x80 >> i;
-            }
-        return accu;
-    }
-}
-else {
-    alias Vec = double[8];
+alias Vec = double[8];
 
-    pragma(inline, true):
-    ubyte mbrot8(Vec cr, double civ) {
-        immutable Vec ci = civ;
-        Vec zr = 0.0;
-        Vec zi = 0.0;
-        Vec tr = 0.0;
-        Vec ti = 0.0;
-        Vec absz = 0.0;
-        foreach(l; 0 .. 10) {
-            foreach(k; 0 .. 5) {
-                zi[] = (zr[] + zr[]) * zi[] + ci[];
-                zr[] = tr[] - ti[] + cr[];
-                tr[] = zr[] * zr[];
-                ti[] = zi[] * zi[];
-            }
-            absz[] = tr[] + ti[];
-            bool terminate = true;
-            foreach(i; 0 .. 8)
-                if (absz[i] <= 4.0) {
-                    terminate = false;
-                    break;
-                }
-            if (terminate)
-                return 0u;
+pragma(inline, true):
+ubyte mbrot8(Vec cr, double civ) {
+    immutable Vec ci = civ;
+    Vec zr = 0.0;
+    Vec zi = 0.0;
+    Vec tr = 0.0;
+    Vec ti = 0.0;
+    Vec absz = 0.0;
+    foreach(l; 0 .. 10) {
+        foreach(k; 0 .. 5) {
+            zi[] = (zr[] + zr[]) * zi[] + ci[];
+            zr[] = tr[] - ti[] + cr[];
+            tr[] = zr[] * zr[];
+            ti[] = zi[] * zi[];
         }
-        ubyte accu;
-        foreach(i; 0 .. VLEN)
+        absz[] = tr[] + ti[];
+        bool terminate = true;
+        foreach(i; 0 .. 8)
             if (absz[i] <= 4.0) {
-                accu |= 0x80 >> i;
+                terminate = false;
+                break;
             }
-        return accu;
+        if (terminate)
+            return 0u;
     }
+    ubyte accu;
+    foreach(i; 0 .. VLEN)
+        if (absz[i] <= 4.0) {
+            accu |= 0x80 >> i;
+        }
+    return accu;
 }
 
 void main(string[] args) {

--- a/bench/include/d/dub.json
+++ b/bench/include/d/dub.json
@@ -9,5 +9,5 @@
 	"name": "app",
 	"targetPath": "out",
 	"dflags-dmd": ["-mcpu=avx2"],
-	"dflags-ldc": ["-mcpu=broadwell"]
+	"dflags-ldc": ["-mattr=+avx2", "-mcpu=broadwell"]
 }

--- a/bench/include/d/dub.json
+++ b/bench/include/d/dub.json
@@ -9,5 +9,5 @@
 	"name": "app",
 	"targetPath": "out",
 	"dflags-dmd": ["-mcpu=avx2"],
-	"dflags-ldc2": ["--march=broadwell"]
+	"dflags-ldc": ["-mcpu=broadwell"]
 }


### PR DESCRIPTION
Based on fix from @kinke (PR/308):
I've removed SIMD-specific realization from Mandelbrot.
Because it seems that currently D is not supporting AVX-512 specific instructions.

Now build and tests are passing (at least locally). The time has been increased :(